### PR TITLE
feat: add coroutine support via ENABLE_CORO cmake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ project(
   DESCRIPTION "The official C++ wrapper for the Top.gg API."
 )
 
+option(ENABLE_CORO "Support for C++20 coroutines" OFF)
+
 file(GLOB TOPGG_SOURCE_FILES src/*.cpp)
 
 add_library(topgg SHARED ${TOPGG_SOURCE_FILES})
@@ -16,6 +18,14 @@ set_target_properties(topgg PROPERTIES
   CXX_STANDARD          17
   CXX_STANDARD_REQUIRED ON
 )
+
+if (ENABLE_CORO)
+    target_compile_definitions(topgg PUBLIC DPP_CORO=ON)
+    set_target_properties(topgg PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+    )
+endif()
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")

--- a/include/topgg/client.h
+++ b/include/topgg/client.h
@@ -41,7 +41,7 @@ namespace topgg {
   /**
    * @brief The callback function to call when post_stats completes.
    */
-  using post_stats_completion_t = std::function<void(void)>;
+  using post_stats_completion_t = std::function<void(bool)>;
 
   /**
    * @brief Base client class for HTTP purposes.
@@ -118,6 +118,10 @@ namespace topgg {
      */
     void get_bot(const dpp::snowflake bot_id, const get_bot_completion_t& callback);
 
+#ifdef DPP_CORO
+    dpp::async<topgg::result<topgg::bot>> co_get_bot(const dpp::snowflake bot_id);
+#endif
+
     /**
      * @brief Fetches a user from a Discord ID.
      *
@@ -143,6 +147,10 @@ namespace topgg {
      */
     void get_user(const dpp::snowflake user_id, const get_user_completion_t& callback);
 
+#ifdef DPP_CORO
+    dpp::async<topgg::result<topgg::user>> co_get_user(const dpp::snowflake user_id);
+#endif
+
     /**
      * @brief Fetches your Discord bot’s statistics.
      *
@@ -166,6 +174,10 @@ namespace topgg {
      * @param callback The callback function to call when get_stats completes.
      */
     void get_stats(const get_stats_completion_t& callback);
+
+#ifdef DPP_CORO
+    dpp::async<topgg::result<topgg::stats>> co_get_stats();
+#endif
 
     /**
      * @brief Fetches your Discord bot’s last 1000 voters.
@@ -193,6 +205,10 @@ namespace topgg {
      */
     void get_voters(const get_voters_completion_t& callback);
 
+#ifdef DPP_CORO
+    dpp::async<topgg::result<std::vector<voter>>> co_get_voters();
+#endif
+
     /**
      * @brief Checks if the specified user has voted your Discord bot.
      *
@@ -218,6 +234,9 @@ namespace topgg {
      */
     void has_voted(const dpp::snowflake user_id, const has_voted_completion_t& callback);
 
+#ifdef DPP_CORO
+    dpp::async<topgg::result<bool>> co_has_voted(const dpp::snowflake user_id);
+#endif
     /**
      * @brief Checks if the weekend multiplier is active.
      *
@@ -242,6 +261,9 @@ namespace topgg {
      */
     void is_weekend(const is_weekend_completion_t& callback);
 
+#ifdef DPP_CORO
+    dpp::async<topgg::result<bool>> co_is_weekend();
+#endif
     /**
      * @brief Manually posts your Discord bot's statistics.
      *
@@ -262,6 +284,10 @@ namespace topgg {
      * @param callback The callback function to call when post_stats completes.
      */
     void post_stats(const stats& s, const post_stats_completion_t& callback);
+
+#ifdef DPP_CORO
+    dpp::async<bool> co_post_stats(const stats& s);
+#endif
 
     friend class autoposter::base;
   };

--- a/include/topgg/result.h
+++ b/include/topgg/result.h
@@ -118,7 +118,7 @@ namespace topgg {
     T get() const {
       m_internal.prepare();
 
-      return m_parse_fn(dpp::json::parse(m_response.body));
+      return m_parse_fn(dpp::json::parse(m_internal.m_response.body));
     }
 
     friend class client;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,11 +22,23 @@ TOPGG_API_ENDPOINT_ARGS(get_bot, const dpp::snowflake bot_id) {
   });
 }
 
+#ifdef DPP_CORO
+dpp::async<topgg::result<topgg::bot>> client::co_get_bot(const dpp::snowflake bot_id) {
+	return dpp::async<topgg::result<topgg::bot>>{ [this, bot_id] <typename C> (C &&cc) { return get_bot(bot_id, std::forward<C>(cc)); }};
+}
+#endif
+
 TOPGG_API_ENDPOINT_ARGS(get_user, const dpp::snowflake user_id) {
   basic_request<topgg::user>("/users/" + std::to_string(user_id), callback, [](const auto& j) {
     return topgg::user{j};
   });
 }
+
+#ifdef DPP_CORO
+dpp::async<topgg::result<topgg::user>> client::co_get_user(const dpp::snowflake user_id) {
+	return dpp::async<topgg::result<topgg::user>>{ [this, user_id] <typename C> (C &&cc) { return get_user(user_id, std::forward<C>(cc)); }};
+}
+#endif
 
 TOPGG_API_ENDPOINT_ARGS(post_stats, const stats& s) {
   auto headers = std::multimap<std::string, std::string>{m_headers};
@@ -34,14 +46,26 @@ TOPGG_API_ENDPOINT_ARGS(post_stats, const stats& s) {
 
   headers.insert(std::pair("Content-Length", std::to_string(s_json.size())));
 
-  m_cluster->request("https://top.gg/api/bots/stats", dpp::m_post, [callback](TOPGG_UNUSED const auto& _) { callback(); }, s_json, "application/json", headers);
+  m_cluster->request("https://top.gg/api/bots/stats", dpp::m_post, [callback](TOPGG_UNUSED const auto& _) { callback(true); }, s_json, "application/json", headers);
 }
+
+#ifdef DPP_CORO
+dpp::async<bool> client::co_post_stats(const stats& s) {
+	return dpp::async<bool>{ [this, s] <typename C> (C &&cc) { return post_stats(s, std::forward<C>(cc)); }};
+}
+#endif
 
 TOPGG_API_ENDPOINT(get_stats) {
   basic_request<topgg::stats>("/bots/stats", callback, [](const auto& j) {
     return topgg::stats{j};
   });
 }
+
+#ifdef DPP_CORO
+dpp::async<topgg::result<topgg::stats>> client::co_get_stats() {
+	return dpp::async<topgg::result<topgg::stats>>{ [this] <typename C> (C &&cc) { return get_stats(std::forward<C>(cc)); }};
+}
+#endif
 
 TOPGG_API_ENDPOINT(get_voters) {
   basic_request<std::vector<topgg::voter>>("/bots/votes", callback, [](const auto& j) {
@@ -55,14 +79,33 @@ TOPGG_API_ENDPOINT(get_voters) {
   });
 }
 
+#ifdef DPP_CORO
+dpp::async<topgg::result<std::vector<topgg::voter>>> client::co_get_voters() {
+	return dpp::async<topgg::result<std::vector<topgg::voter>>>{ [this] <typename C> (C &&cc) { return get_voters(std::forward<C>(cc)); }};
+}
+#endif
+
+
 TOPGG_API_ENDPOINT_ARGS(has_voted, const dpp::snowflake user_id) {
   basic_request<bool>("/bots/votes?userId=" + std::to_string(user_id), callback, [](const auto& j) {
     return j["voted"].template get<uint8_t>() != 0;
   });
 }
 
+#ifdef DPP_CORO
+dpp::async<topgg::result<bool>> client::co_has_voted(const dpp::snowflake user_id) {
+	return dpp::async<topgg::result<bool>>{ [user_id, this] <typename C> (C &&cc) { return has_voted(user_id, std::forward<C>(cc)); }};
+}
+#endif
+
 TOPGG_API_ENDPOINT(is_weekend) {
   basic_request<bool>("/weekend", callback, [](const auto& j) {
     return j["is_weekend"].template get<bool>();
   });
 }
+
+#ifdef DPP_CORO
+dpp::async<topgg::result<bool>> client::co_is_weekend() {
+	return dpp::async<topgg::result<bool>>{ [this] <typename C> (C &&cc) { return is_weekend(std::forward<C>(cc)); }};
+}
+#endif


### PR DESCRIPTION
This PR adds support for D++ asynchronous coroutines.

For this to work you must:
* Use a C++20 supporting compiler (g++11 onwards etc)
* build and install D++ with the `DPP_CORO` cmake flag
* build cpp-sdk with the `ENABLE_CORO` flag

Building with this flag will reveal new functions in the SDK client. Each of the functions such as `get_user` will have a coroutine equivalent starting with `co_` (this is the naming convention of D++, copied from C++ standards). The coroutine equivalent will have no callback parameter and can be awaited.

So, the basic example would become instead:

```cpp
#include <topgg/topgg.h>
#include <dpp/dpp.h>
#include <iostream>

int main() {
  dpp::cluster bot{"your bot token"};
  topgg::client topgg_client{&bot, "your top.gg token"};

  const auto result = co_await topgg_client.co_get_bot(264811613708746752);
  try {
    const auto topgg_bot = result.get();
    std::cout << topgg_bot.username << std::endl;
  } catch (const std::exception& ext) {
    std::cout << "error: " << ext.what() << std::endl;
  }

  return 0;
}
```

This is nicer, as it avoids callback hell, and program flow reads in a nicer way. This is of course completely optional and if you don't want to use coroutines, or if you can't, the existing API calls will work exactly as before.