### PR TITLE
feat: nicer, simpler autoposter, using D++ timer and no need for thread nonesense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/*.deb
 **/*.rpm
-
+.idea
+cmake-build-debug/
 include/dpp/
 build/
 deps/

--- a/include/topgg/autoposter.h
+++ b/include/topgg/autoposter.h
@@ -2,129 +2,45 @@
 
 #include <topgg/topgg.h>
 
-#include <condition_variable>
-#include <unordered_set>
-#include <chrono>
-#include <memory>
-#include <mutex>
-
 namespace topgg {
+
   namespace autoposter {
-    class cached;
-
-    /**
-     * @brief A modified semaphore that can be aborted.
-     * This class is private and can't be used outside of topgg's internal code.
-     */
-    class killable_semaphore {
-      std::mutex m_mutex;
-      std::condition_variable m_condition;
-      size_t m_count;
-      bool m_killed;
-
-      inline killable_semaphore(const size_t count)
-        : m_count(count), m_killed(false) {}
-
-      void release();
-      bool acquire();
-      void kill();
-
-    public:
-      /**
-       * @brief No outsiders are allowed to use this class, internal use only :)
-       */
-      killable_semaphore() = delete;
 
       /**
-       * @brief This class can't be copied.
+       * @brief Base class for autoposter classes.
        */
-      killable_semaphore(const killable_semaphore& other) = delete;
+      class TOPGG_EXPORT base: private ::topgg::base_client {
 
       /**
-       * @brief This class can't be moved.
+       * D++ timer handle. D++ timers have a one second resolution,
+       * and can be set to any number of seconds. They will repeat
+       * until stopped or the cluster is destructed.
        */
-      killable_semaphore(killable_semaphore&& other) = delete;
+      dpp::timer m_timer_handle{};
 
       /**
-       * @brief This class can't be assigned from other objects.
+       * Must return true to fetch the statistics
+       * @return
        */
-      killable_semaphore& operator=(const killable_semaphore& other) & = delete;
-
-      /**
-       * @brief This class can't be assigned from other objects.
-       */
-      killable_semaphore& operator=(killable_semaphore&& other) & = delete;
-
-      friend class cached;
-    };
-
-    class base;
-
-    /**
-     * @brief A modified timer that can be aborted.
-     * This class is private and can't be used outside of topgg's internal code.
-     */
-    class killable_waiter {
-      std::mutex m_mutex;
-      std::condition_variable m_condition;
-      size_t m_killed;
-
-      inline killable_waiter()
-        : m_killed(false) {}
-
-      template<class R, class P>
-      bool wait(const std::chrono::duration<R, P>& delay) {
-        std::unique_lock<std::mutex> lock{m_mutex};
-
-        m_condition.wait_for(lock, delay, [this]() -> bool { return this->m_killed; });
-
-        return !m_killed;
-      }
-
-      void kill();
-
-    public:
-      /**
-       * @brief This class can't be copied.
-       */
-      killable_waiter(const killable_waiter& other) = delete;
-
-      /**
-       * @brief This class can't be moved.
-       */
-      killable_waiter(killable_waiter&& other) = delete;
-
-      /**
-       * @brief This class can't be assigned from other objects.
-       */
-      killable_waiter& operator=(const killable_waiter& other) & = delete;
-
-      /**
-       * @brief This class can't be assigned from other objects.
-       */
-      killable_waiter& operator=(killable_waiter&& other) & = delete;
-
-      friend class base;
-    };
-
-    /**
-     * @brief Base class for autoposter classes.
-     * This class stores autoposter thread and handles requests with the API, with methods to be implemented by its child classes.
-     */
-    class TOPGG_EXPORT base: private ::topgg::base_client {
-      killable_waiter m_waiter;
-      std::thread m_thread;
-
       virtual inline bool before_fetch() {
         return true;
       }
 
-      virtual inline void after_fetch() {}
+      /**
+       * Called after fetching statistics
+       */
+      virtual inline void after_fetch() {
+      }
 
+      /**
+       * Implement this interface to return the bot's statistics
+       * @param bot D++ cluster
+       * @return topgg::stats instance
+       */
       virtual ::topgg::stats get_stats(dpp::cluster* bot) = 0;
-      void thread_loop(dpp::cluster* thread_cluster);
 
     protected:
+
       /**
        * @brief A shared pointer to the bot's D++ cluster.
        */
@@ -133,30 +49,15 @@ namespace topgg {
       /**
        * @brief Constructs the base autoposter class.
        *
-       * @param cluster A shared pointer to the bot's D++ cluster. This pointer will be used later in the autoposter thread.
+       * @param cluster A shared pointer to the bot's D++ cluster.
        * @param token The Top.gg API token to use.
-       * @param delay The minimum delay between post requests. This delay mustn't be shorter than 15 minutes.
-       * @throw std::invalid_argument Throwns if the delay argument is shorter than 15 minutes.
+       * @param delay The minimum delay between post requests in seconds. This delay mustn't be shorter than 15 minutes.
+       * @throw std::invalid_argument Throws if the delay argument is shorter than 15 minutes.
        */
-      template<class R, class P>
-      base(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const std::chrono::duration<R, P>& delay)
-        : ::topgg::base_client(token), m_cluster(std::shared_ptr{cluster}) {
-        if (delay < std::chrono::minutes(15)) {
-          throw std::invalid_argument{"Delay mustn't be shorter than 15 minutes."};
-        }
-
-        // clang-format off
-        m_thread = std::thread([this](const std::chrono::duration<R, P>& t_delay) {
-          std::shared_ptr<dpp::cluster> thread_cluster{this->m_cluster};
-
-          while (this->m_waiter.wait(t_delay) && this->before_fetch()) {
-            this->thread_loop(thread_cluster.get());
-          }
-        }, std::cref(delay));
-        // clang-format on
-      }
+      base(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const time_t delay);
 
     public:
+
       /**
        * @brief Don't use this class directly. Use its child classes!
        */
@@ -164,70 +65,64 @@ namespace topgg {
 
       /**
        * @brief This class can't be copied.
+       * @param other other
        */
       base(const base& other) = delete;
 
       /**
        * @brief This class can't be moved.
+       * @param other other
        */
       base(base&& other) = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       base& operator=(const base& other) & = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       base& operator=(base&& other) & = delete;
 
       /**
-       * @brief Requests the autoposter thread to stop.
-       * @note This function does NOT block and wait for the thread to stop. That's the destructor's job.
+       * @brief Requests the autoposter timer to stop.
+       * @note This function immediately stops the timer, it does not need to block.
        */
       virtual void stop();
 
       /**
-       * @brief Requests the autoposter thread to stop and blocks until the thread is completely shut down.
+       * @brief Requests the autoposter timer to stop. It does not need to block.
        */
       ~base();
+
     };
 
     /**
-     * @brief An autoposter class that automatically retrieves the server count itself by manually listening to Discord's gateway events.
+     * @brief An autoposter class that automatically retrieves the server count itself by using D++ cache.
+     * @note Depends on guild cache being enabled in D++ (this is the default)
      */
-    class TOPGG_EXPORT cached: public base {
-      std::mutex m_mutex;
-      killable_semaphore m_semaphore;
-      std::unordered_set<dpp::snowflake> m_guilds;
+    class TOPGG_EXPORT cached : public base {
 
-      bool before_fetch() override;
-
-      inline void after_fetch() override {
-        m_mutex.unlock();
-      }
-
-      void start_listening();
-
-      inline ::topgg::stats get_stats(TOPGG_UNUSED dpp::cluster* _) override {
-        return ::topgg::stats{m_guilds.size()};
-      }
+      /**
+       * Retrieve stats using the D++ guild cache
+       * @param bot cluster pointer
+       * @return topgg::stats
+       */
+      ::topgg::stats get_stats(TOPGG_UNUSED dpp::cluster* bot) override;
 
     public:
       /**
        * @brief Constructs the autoposter class.
        *
-       * @param cluster A shared pointer to the bot's D++ cluster. This pointer will be used later in the autoposter thread.
+       * @param cluster A shared pointer to the bot's D++ cluster. This pointer is used in the timer handler.
        * @param token The Top.gg API token to be used.
-       * @param delay The minimum delay between post requests. This delay mustn't be shorter than 15 minutes.
-       * @throw std::invalid_argument Throwns if the delay argument is shorter than 15 minutes.
+       * @param delay The minimum delay between post requests in seconds. This delay mustn't be shorter than 15 minutes.
+       * @throw std::invalid_argument Throws if the delay argument is shorter than 15 minutes.
        */
-      template<class R, class P>
-      inline cached(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const std::chrono::duration<R, P>& delay)
-        : base(cluster, token, delay), m_semaphore(killable_semaphore{0}) {
-        start_listening();
-      }
+      cached(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const time_t delay);
 
       /**
        * @brief That's not how you initiate the class buddy :)
@@ -236,37 +131,44 @@ namespace topgg {
 
       /**
        * @brief This class can't be copied.
+       * @param other other
        */
       cached(const cached& other) = delete;
 
       /**
        * @brief This class can't be moved.
+       * @param other other
        */
       cached(cached&& other) = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       cached& operator=(const cached& other) & = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       cached& operator=(cached&& other) & = delete;
-
-      /**
-       * @brief Requests the autoposter thread to stop.
-       * @note This function does NOT block and wait for the thread to stop. That's the destructor's job.
-       */
-      void stop() override;
     };
 
     /**
      * @brief An autoposter class that lets you manually retrieve the stats.
      */
-    class TOPGG_EXPORT custom: public base {
+    class TOPGG_EXPORT custom : public base {
+
+      /**
+       * Callback for retrieving stats
+       */
       std::function<::topgg::stats(dpp::cluster*)> m_callback;
 
+      /**
+       * Calls the callback to get the stats
+       * @param bot D++ cluster
+       * @return topgg::stats
+       */
       inline ::topgg::stats get_stats(dpp::cluster* bot) override {
         return m_callback(bot);
       }
@@ -275,14 +177,13 @@ namespace topgg {
       /**
        * @brief Constructs the autoposter class.
        *
-       * @param cluster A shared pointer to the bot's D++ cluster. This pointer will be used later in the autoposter thread.
+       * @param cluster A shared pointer to the bot's D++ cluster. This pointer is used in the timer handler.
        * @param token The Top.gg API token to be used.
-       * @param delay The minimum delay between post requests. This delay mustn't be shorter than 15 minutes.
+       * @param delay The minimum delay between post requests in seconds. This delay mustn't be shorter than 15 minutes.
        * @param callback The callback function that returns the current stats.
-       * @throw std::invalid_argument Throwns if the delay argument is shorter than 15 minutes.
+       * @throw std::invalid_argument Throws if the delay argument is shorter than 15 minutes.
        */
-      template<class R, class P>
-      inline custom(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const std::chrono::duration<R, P>& delay, std::function<::topgg::stats(dpp::cluster*)>&& callback)
+      inline custom(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const time_t delay, std::function<::topgg::stats(dpp::cluster*)>&& callback)
         : base(cluster, token, delay), m_callback(callback) {}
 
       /**
@@ -292,23 +193,29 @@ namespace topgg {
 
       /**
        * @brief This class can't be copied.
+       * @param other other
        */
       custom(const custom& other) = delete;
 
       /**
        * @brief This class can't be moved.
+       * @param other other
        */
       custom(custom&& other) = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       custom& operator=(const custom& other) & = delete;
 
       /**
        * @brief This class can't be assigned from other objects.
+       * @param other other
        */
       custom& operator=(custom&& other) & = delete;
     };
+
   }; // namespace autoposter
+
 }; // namespace topgg

--- a/src/autoposter.cpp
+++ b/src/autoposter.cpp
@@ -3,112 +3,54 @@
 
 using topgg::autoposter::base;
 using topgg::autoposter::cached;
-using topgg::autoposter::killable_semaphore;
-using topgg::autoposter::killable_waiter;
 using topgg::stats;
 
-void killable_semaphore::release() {
-  std::lock_guard<std::mutex> lock{m_mutex};
-
-  ++m_count;
-  m_condition.notify_all();
-}
-
-bool killable_semaphore::acquire() {
-  std::unique_lock<std::mutex> lock{m_mutex};
-
-  while (m_count == 0 && !m_killed) {
-    m_condition.wait(lock);
-  }
-
-  m_count = 0;
-  return !m_killed;
-}
-
-void killable_semaphore::kill() {
-  std::lock_guard<std::mutex> lock{m_mutex};
-
-  m_killed = true;
-  m_condition.notify_all();
-}
-
-void killable_waiter::kill() {
-  std::lock_guard<std::mutex> lock{m_mutex};
-
-  m_killed = true;
-  m_condition.notify_all();
-}
-
-void base::thread_loop(dpp::cluster* thread_cluster) {
-  const auto s = get_stats(thread_cluster);
-
-  after_fetch();
-
-  const auto s_json = s.to_json();
-  std::multimap<std::string, std::string> headers{m_headers};
-
-  headers.insert(std::pair("Content-Length", std::to_string(s_json.size())));
-
-  thread_cluster->request("https://top.gg/api/bots/stats", dpp::m_post, [](TOPGG_UNUSED const auto& _) {}, s_json, "application/json", headers);
-}
-
 void base::stop() {
-  m_waiter.kill();
+  if (m_timer_handle) {
+    m_cluster->stop_timer(m_timer_handle);
+  }
+  m_timer_handle = 0;
 }
 
 base::~base() {
-  stop();
-  m_thread.join();
-}
-
-void cached::start_listening() {
-  auto this_cluster = m_cluster.get();
-
-  this_cluster->on_ready([this](const auto& event) {
-    if (dpp::run_once<struct _>()) {
-      this->m_mutex.lock();
-
-      for (const auto& guild: event.guilds) {
-        this->m_guilds.insert(guild);
-      }
-
-      this->m_mutex.unlock();
-      this->m_semaphore.release();
-    }
-  });
-
-  this_cluster->on_guild_create([this](const auto& event) {
-    if (!event.created->is_unavailable()) {
-      this->m_mutex.lock();
-
-      this->m_guilds.insert(event.created->id);
-
-      this->m_mutex.unlock();
-      this->m_semaphore.release();
-    }
-  });
-
-  this_cluster->on_guild_delete([this](const auto& event) {
-    this->m_mutex.lock();
-
-    this->m_guilds.erase(event.deleted.id);
-
-    this->m_mutex.unlock();
-    this->m_semaphore.release();
-  });
-}
-
-bool cached::before_fetch() {
-  if (m_semaphore.acquire()) {
-    m_mutex.lock();
-
-    return true;
-  }
-
-  return false;
-}
-
-void cached::stop() {
   base::stop();
-  m_semaphore.kill();
+}
+
+
+base::base(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const time_t delay)
+  : ::topgg::base_client(token), m_cluster(std::shared_ptr{cluster}) {
+  /**
+   * Check the timer duration is not less than 15 minutes
+   */
+  if (delay < 15 * 60) {
+    throw std::invalid_argument{"Delay mustn't be shorter than 15 minutes."};
+  }
+  /**
+   * Create a D++ timer, this is managed by the D++ cluster and ticks every n seconds.
+   * It can be stopped at any time without blocking, and does not need to create extra threads.
+   */
+  this->m_timer_handle = cluster->start_timer([this, cluster, token](dpp::timer) {
+    if (this->before_fetch()) {
+      const auto s = get_stats(cluster.get());
+      after_fetch();
+      const auto s_json = s.to_json();
+      std::multimap<std::string, std::string> headers{m_headers};
+      headers.insert(std::pair("Content-Length", std::to_string(s_json.size())));
+      cluster->request("https://top.gg/api/bots/stats", dpp::m_post, [](TOPGG_UNUSED const auto&) {}, s_json, "application/json", headers);
+    }
+  }, delay);
+}
+
+::topgg::stats cached::get_stats(TOPGG_UNUSED dpp::cluster* bot) {
+  /**
+   * Count guilds and shards using D++ guild cache and shards map
+   */
+  size_t servers = 0;
+  for (auto & s : bot->get_shards()) {
+    servers += s.second->get_guild_count();
+  }
+  return ::topgg::stats{servers, bot->get_shards().size()};
+}
+
+cached::cached(std::shared_ptr<dpp::cluster>& cluster, const std::string& token, const time_t delay) : base(cluster, token, delay) {
 }


### PR DESCRIPTION
Wise man say, he who add threads to code now have `two probtw oprob probltwo two problems`.

Made the autoposter much nicer.

Also removed a lot of the inline jank. Inlining the classes means its compiled again each time for each TU where its included, this isnt really the C++ way, it is down to the compiler to decide what to inline and generally it knows better than we do.

As a future aside i'd like to remove some of the deep namespacing and OOP-abuse from this, but i dont want to break backwards compatibility too much.